### PR TITLE
Fix for map reset/zoom-out / `xlink:title` tooltips on d3.js map-markers

### DIFF
--- a/js/leaflet-map.js
+++ b/js/leaflet-map.js
@@ -6,6 +6,8 @@
 */
 var OERRH = OERRH || {};
 
+OERRH.geomap.no_loc_count = 0;
+
 window.console && console.log("OERRH:", OERRH);
 
 var iconuri = pluginurl+'images/icons/';
@@ -139,7 +141,10 @@ function renderLayer(switches){
 							// Move "no location" markers [LACE][Bug: #50]
 							//if (no_loc && !coord[0] && !coord[1])
 							if (no_loc && near_zero(coord[0]) && near_zero(coord[1])) {
-								window.console && console.log("No location?", coord, prop);
+
+								OERRH.geomap.no_loc_count++;
+
+								//window.console && console.log("No location?", coord, prop);
 
 								// Re-locate ... swap!
 								coord[ 0 ] = no_loc[ 1 ];
@@ -318,7 +323,7 @@ jQuery(document).ready(function($){
 
 	// Mark "no location" evidence [LACE][Bug: #50]
 	var no_loc = OERRH.geomap.no_location_latlng;
-	if (no_loc) {
+	if (no_loc && OERRH.geomap.no_loc_count > 0) {
 
 		var lace_no_location_pop = L.popup({ className: "lace-no-location-pop" })
 			.setLatLng(no_loc)

--- a/lib/map/src/main.js
+++ b/lib/map/src/main.js
@@ -323,7 +323,7 @@ var selectCountry = function(id, showTooltip){
 }
 
 function displaySankey(d){
-	var slug = d.slug || "World";
+	var slug = (d && d.slug) || "World";
 	console.log(slug);
 	//if (slug != "World"){
 	var country = map.selectAll('.country').filter(function(d,i){

--- a/lib/map/src/main.js
+++ b/lib/map/src/main.js
@@ -1007,7 +1007,19 @@ var displayBarchartData = function(data, worlddata) {
 
 var displayMarkers = function(data){
 	marker = map.select('#markers').selectAll('.marker').data(data);
-	
+
+	function _X_1_tpl(str, args) {
+		for (var it in args) {
+			str = str.replace(it, args[ it ]);
+		}
+		return str;
+	}
+
+	function _tpl(str, obj, pre, suf) {
+		var re = new RegExp((pre || "_") + "([a-z]+)" + (suf || ""), "g");
+		return str.replace(re, function (m, p1, of) { return obj[ p1 ] });
+	}
+
 	// UPDATE
     marker
         .transition()
@@ -1019,6 +1031,9 @@ var displayMarkers = function(data){
 	marker.enter()
 		.append("svg:a")
 	    .attr("xlink:href", function(d) { return d.url; })
+	    .attr("xlink:title", function (d) {
+	    	return _tpl("_n\nPolarity: _p | Sector: _s", { n: d.name, p: d.polarity, s: d.sector });
+	    })
 	    .append('circle')
 		.attr('class', function(d){ return 'marker '+d.polarity+' '+d.sector} )
 		.attr('cx', function(d){ return projection([d.lng,d.lat])[0];})

--- a/shortcodes/class-shortcode.php
+++ b/shortcodes/class-shortcode.php
@@ -304,11 +304,26 @@ abstract class Evidence_Hub_Shortcode extends Evidence_Hub_Base {
 	<!--[if lte IE 10]>
 		<style> #fullscreen-button { display:none; } </style>
 	<![endif]-->
-		<div id="fullscreen-button" class="map-controls">
-		  <!--[Bug: #40]-->
-		  <a href="#!zoom-out" id="map-reset-button" onclick="displaySankey && displaySankey();return false"><i class="el-icon-refresh x-el-icon-zoom-out"></i>Zoom out</a>
-		  <?php #<a href="#" id="map-reset-button" onclick="document.location.reload();return false"><i class="el-icon-refresh x-el-icon-zoom-out"></i>Refresh map</a> ?> <i class=sep ></i>
-		  <a href="#!full-screen" id="evidence-map-fullscreen"><i class=el-icon-fullscreen ></i>Full Screen</a>
+	<div id="fullscreen-button" class="map-controls">
+	<!--[Bug: #40]-->
+	<script>
+	var OERRH = OERRH || {};
+
+	OERRH.resetMap = function () {
+		// D3.js map.
+		if (window.displaySankey) {
+			displaySankey();  //'World'
+		}
+		// Leaflet.JS map.
+		else if (OERRH.geomap && OERRH.geomap.map.setView) {
+			OERRH.geomap.map.setView(OERRH.geomap.center || [25, 0], 2);
+		}
+		return false;
+	};
+	</script>
+	<a href="#!zoom-out" id="map-reset-button" onclick="return OERRH.resetMap()"><i class="el-icon-refresh x-el-icon-zoom-out"></i>Zoom out</a> <i class=sep ></i>
+	<?php #<a href="#" id="map-reset-button" onclick="document.location.reload();return false"><i></i>Refresh map</a> ?>
+	<a href="#!full-screen" id="evidence-map-fullscreen"><i class=el-icon-fullscreen ></i>Full Screen</a>
 		</div>
 		<script src="<?php echo plugins_url( 'lib/map/lib/bigscreen.min.js' , EVIDENCE_HUB_REGISTER_FILE )?>" charset="utf-8"></script>
 		<script>

--- a/shortcodes/class-shortcode.php
+++ b/shortcodes/class-shortcode.php
@@ -306,8 +306,9 @@ abstract class Evidence_Hub_Shortcode extends Evidence_Hub_Base {
 	<![endif]-->
 		<div id="fullscreen-button" class="map-controls">
 		  <!--[Bug: #40]-->
-		  <a href="#" id="map-reset-button" onclick="document.location.reload();return false"><i class="el-icon-refresh x-el-icon-zoom-out"></i>Refresh map</a> <i class=sep ></i>
-		  <a href="#" id="evidence-map-fullscreen"><i class=el-icon-fullscreen ></i>Full Screen</a>
+		  <a href="#!zoom-out" id="map-reset-button" onclick="displaySankey && displaySankey();return false"><i class="el-icon-refresh x-el-icon-zoom-out"></i>Zoom out</a>
+		  <?php #<a href="#" id="map-reset-button" onclick="document.location.reload();return false"><i class="el-icon-refresh x-el-icon-zoom-out"></i>Refresh map</a> ?> <i class=sep ></i>
+		  <a href="#!full-screen" id="evidence-map-fullscreen"><i class=el-icon-fullscreen ></i>Full Screen</a>
 		</div>
 		<script src="<?php echo plugins_url( 'lib/map/lib/bigscreen.min.js' , EVIDENCE_HUB_REGISTER_FILE )?>" charset="utf-8"></script>
 		<script>

--- a/shortcodes/geomap-key.php
+++ b/shortcodes/geomap-key.php
@@ -1,18 +1,24 @@
 <?php
 /**
  * Key for [geomap] shortcode (class-general_geomap.php).
+ *
+ * @link  js/markercluster/leaflet.markercluster-src.js#L620-626  Cluster boundaries.
  */
 ?>
+
 <div id="key" class="evidence-map-key geomap-key key-type-<?php echo $type ?>">
 <h3>Key</h3>
 <ul>
-  <li class="marker cluster"><div class="marker-cluster marker-cluster-small" ><div><span>2</span></div></div> Small cluster: limited evidence <small>(green)</small>
-  <li class="marker cluster"><div class="marker-cluster marker-cluster-medium"><div><span>21</span></div></div> Medium cluster: more than 20 pieces of evidence <small>(orange)</small>
-  <li class="marker cluster"><div class="marker-cluster marker-cluster-large" ><div><span>201</span></div></div> Large cluster  <small>(red)</small>
+  <li class="marker cluster"><div class="marker-cluster marker-cluster-small" ><div><span>2</span></div></div>
+    Small cluster: <?php if('evidence'==$type):?>limited evidence<?php else:?>a limited number of items<?php endif;?> <small>(green)</small>
+  <li class="marker cluster"><div class="marker-cluster marker-cluster-medium"><div><span>21</span></div></div>
+    Medium cluster: more than 20 items <?php if('evidence'==$type):?>of evidence<?php endif;?> <small>(orange)</small>
+  <li class="marker cluster"><div class="marker-cluster marker-cluster-large" ><div><span>101</span></div></div>
+    Large cluster: more than 100 items <?php if('evidence'==$type):?>of evidence<?php endif;?> <small>(red)</small>
 
   <li class="marker evidence evidence-pos"     > Positive evidence <small>(orange pin)</small>
-  <li class="marker evidence evidence-neutral" > Neutral/mixed evidence <small>(blue pin)</small>
-  <li class="marker evidence"                  > Polarity not given <small>(blue pin)</small>
+  <li class="marker evidence evidence-neutral" > Neutral evidence, mixed evidence or no polarity given <small>(blue pin)</small>
+  <?php #<li class="marker evidence"             > Polarity not given <small>(blue pin)</small> ?>
   <li class="marker evidence evidence-neg"     > Negative evidence <small>(grey pin)</small>
 
   <li class="marker project"> Project <small>(dark blue pin)</small>

--- a/shortcodes/geomap-key.php
+++ b/shortcodes/geomap-key.php
@@ -9,10 +9,10 @@
 <div id="key" class="evidence-map-key geomap-key key-type-<?php echo $type ?>">
 <h3>Key</h3>
 <ul>
-  <li class="marker cluster"><div class="marker-cluster marker-cluster-small" ><div><span>2</span></div></div>
+  <li class="marker cluster"><div class="marker-cluster marker-cluster-small" ><div><span>1</span></div></div>
     Small cluster: <?php if('evidence'==$type):?>limited evidence<?php else:?>a limited number of items<?php endif;?> <small>(green)</small>
   <li class="marker cluster"><div class="marker-cluster marker-cluster-medium"><div><span>21</span></div></div>
-    Medium cluster: more than 20 items <?php if('evidence'==$type):?>of evidence<?php endif;?> <small>(orange)</small>
+    Medium cluster: more than 20 items <?php if('evidence'==$type):?>of evidence<?php endif;?> <small>(yellow)</small>
   <li class="marker cluster"><div class="marker-cluster marker-cluster-large" ><div><span>101</span></div></div>
     Large cluster: more than 100 items <?php if('evidence'==$type):?>of evidence<?php endif;?> <small>(red)</small>
 


### PR DESCRIPTION
Hi Martin,

Thank you for getting on with pull #56 - much appreciated, as I was buried in my work.

The highlights of this quite small follow-up request are:
- #40 - a proper fix for map reset/zoom-out for both Leaflet & d3.js based maps that doesn't require a page refresh;
- #57 - `xlink:title` tool-tips for markers (SVG links) on the d3.js based map(s);

You'll note that it doesn't include fixes for #49 / #53, which are on the [CR53-js branch](https://github.com/IET-OU/wp-evidence-hub/tree/CR53-js) - it needs debugging... ;).

Thanks,

Nick
